### PR TITLE
feat(data): Add Room data layer and DI for tasks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "br.com.cpcjrdev.todoapp"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
@@ -61,4 +61,5 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     implementation(project(":presentation"))
+    implementation(project(":data"))
 }

--- a/app/src/main/java/br/com/cpcjrdev/todoapp/TodoApplication.kt
+++ b/app/src/main/java/br/com/cpcjrdev/todoapp/TodoApplication.kt
@@ -1,0 +1,14 @@
+package br.com.cpcjrdev.todoapp
+
+import android.app.Application
+import br.com.cpcjrdev.data.di.AppContainer
+
+class TodoApplication : Application() {
+    lateinit var appContainer: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        appContainer = AppContainer.getInstance(this)
+    }
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.android.devtools.ksp)
 }
 
 android {
@@ -8,7 +9,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -40,7 +41,15 @@ dependencies {
 //    implementation(libs.androidx.core.ktx)
 //    implementation(libs.androidx.appcompat)
 //    implementation(libs.material)
+
+    implementation(libs.room.runtime)
+    ksp(libs.room.compiler)
+    annotationProcessor(libs.room.compiler)
+    implementation(libs.room.ktx)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation(project(":domain"))
 }

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-</manifest>

--- a/data/src/main/java/br/com/cpcjrdev/data/dao/TasksDao.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/dao/TasksDao.kt
@@ -1,0 +1,27 @@
+package br.com.cpcjrdev.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import br.com.cpcjrdev.data.entities.TasksEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TasksDao {
+    @Insert
+    suspend fun insert(tasks: TasksEntity)
+
+    @Query("SELECT * FROM tasks")
+    fun getAll(): Flow<List<TasksEntity>>
+
+    @Query("SELECT * FROM tasks WHERE id = :id")
+    suspend fun getById(id: Long): TasksEntity?
+
+    @Update
+    suspend fun update(tasks: TasksEntity): Int
+
+    @Delete
+    suspend fun delete(tasks: TasksEntity): Int
+}

--- a/data/src/main/java/br/com/cpcjrdev/data/database/DatabaseProvider.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/database/DatabaseProvider.kt
@@ -1,0 +1,52 @@
+package br.com.cpcjrdev.data.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import br.com.cpcjrdev.data.dao.TasksDao
+import br.com.cpcjrdev.data.database.DatabaseProvider.Companion.getDatabase
+import br.com.cpcjrdev.data.entities.TasksEntity
+
+/**
+ * Room Database provider and singleton holder for the application.
+ *
+ * Use [getDatabase] to retrieve the singleton instance.
+ * Uses [context.applicationContext] to avoid memory leaks.
+ *
+ * @note Migration responsibility is on the developer as fallbackToDestructiveMigration(false) is set.
+ */
+@Database(
+    version = 1,
+    entities = [TasksEntity::class],
+)
+abstract class DatabaseProvider : RoomDatabase() {
+    abstract fun tasksDao(): TasksDao
+
+    companion object {
+        @Volatile
+        private var instance: DatabaseProvider? = null
+
+        /**
+         * Returns the singleton instance of DatabaseProvider.
+         *
+         * Uses the [applicationContext] to prevent leaking an Activity or other Context.
+         * @param context any context (application context will be used internally)
+         * @return database singleton instance
+         */
+
+        fun getDatabase(context: Context): DatabaseProvider {
+            // if the Instance is not null, return it, otherwise create a new database instance.
+            return instance ?: synchronized(this) {
+                Room
+                    .databaseBuilder(
+                        context.applicationContext, // safer context
+                        DatabaseProvider::class.java,
+                        "todo_db",
+                    ).fallbackToDestructiveMigration(false) // you must provide migrations for db upgrades
+                    .build()
+                    .also { instance = it }
+            }
+        }
+    }
+}

--- a/data/src/main/java/br/com/cpcjrdev/data/di/AppContainer.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/di/AppContainer.kt
@@ -1,0 +1,35 @@
+package br.com.cpcjrdev.data.di
+
+import android.content.Context
+import br.com.cpcjrdev.data.database.DatabaseProvider
+import br.com.cpcjrdev.data.repository.TasksDataRepository
+
+/**
+ * Dependency injection container for application-wide singletons.
+ */
+interface DependencyContainer {
+    val tasksDataRepository: TasksDataRepository
+}
+
+class AppContainer(
+    context: Context,
+    private val database: DatabaseProvider = DatabaseProvider.getDatabase(context.applicationContext),
+) : DependencyContainer {
+    override val tasksDataRepository: TasksDataRepository by lazy {
+        TasksDataRepository(database.tasksDao())
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AppContainer? = null
+
+        /**
+         * Returns the singleton instance of [AppContainer].
+         * Uses [applicationContext] to prevent Context leaks.
+         */
+        fun getInstance(context: Context): AppContainer =
+            instance ?: synchronized(this) {
+                instance ?: AppContainer(context.applicationContext).also { instance = it }
+            }
+    }
+}

--- a/data/src/main/java/br/com/cpcjrdev/data/entities/TasksEntity.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/entities/TasksEntity.kt
@@ -1,0 +1,12 @@
+package br.com.cpcjrdev.data.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "tasks")
+data class TasksEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long?,
+    val title: String,
+    val description: String,
+)

--- a/data/src/main/java/br/com/cpcjrdev/data/mappers/TasksMappers.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/mappers/TasksMappers.kt
@@ -1,0 +1,18 @@
+package br.com.cpcjrdev.data.mappers
+
+import br.com.cpcjrdev.data.entities.TasksEntity
+import br.com.cpcjrdev.data.model.Tasks
+
+fun Tasks.toTasksEntity(id: Long? = null): TasksEntity =
+    TasksEntity(
+        id = id,
+        title = this.title,
+        description = this.description,
+    )
+
+fun TasksEntity.toTasks(): Tasks =
+    Tasks(
+        id = this.id ?: 0,
+        title = this.title,
+        description = this.description,
+    )

--- a/data/src/main/java/br/com/cpcjrdev/data/model/Tasks.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/model/Tasks.kt
@@ -1,4 +1,4 @@
-package br.com.cpcjrdev.domain.model
+package br.com.cpcjrdev.data.model
 
 data class Tasks(
     val id: Long,

--- a/data/src/main/java/br/com/cpcjrdev/data/repository/TasksDataRepository.kt
+++ b/data/src/main/java/br/com/cpcjrdev/data/repository/TasksDataRepository.kt
@@ -1,0 +1,23 @@
+package br.com.cpcjrdev.data.repository
+
+import br.com.cpcjrdev.data.dao.TasksDao
+import br.com.cpcjrdev.data.mappers.toTasks
+import br.com.cpcjrdev.data.mappers.toTasksEntity
+import br.com.cpcjrdev.data.model.Tasks
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TasksDataRepository(
+    private val dao: TasksDao,
+) {
+    fun fetchTasks(): Flow<List<Tasks>> =
+        dao.getAll().map { it ->
+            it.map { it.toTasks() }
+        }
+
+    suspend fun insertTasks(tasks: Tasks) = dao.insert(tasks.toTasksEntity(tasks.id))
+
+    suspend fun deleteTasks(tasks: Tasks) = dao.delete(tasks.toTasksEntity(tasks.id))
+
+    suspend fun updateTasks(tasks: Tasks) = dao.update(tasks.toTasksEntity(tasks.id))
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,8 @@ activityCompose = "1.10.1"
 composeBom = "2025.06.01"
 appcompat = "1.7.1"
 material = "1.12.0"
+room = "2.7.2"
+androidKsp = "2.2.0-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,9 +31,15 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
+# Room
+room-runtime = {group = "androidx.room", name = "room-runtime", version.ref = "room"}
+room-compiler = {group = "androidx.room", name = "room-compiler" , version.ref = "room"}
+room-ktx = {group = "androidx.room", name = "room-ktx", version.ref = "room"}
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+android-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "androidKsp"}
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 24
+        minSdk = 26
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/presentation/src/main/java/br/com/cpcjrdev/presentation/ui/listscreen/ListScreen.kt
+++ b/presentation/src/main/java/br/com/cpcjrdev/presentation/ui/listscreen/ListScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit


### PR DESCRIPTION
* Introduces a new data module with Room database integration, including TasksEntity, TasksDao, and TasksDataRepository.
* Adds dependency injection via AppContainer, and moves the Tasks model to the data module.
* Updates build scripts to support Room and KSP, raises minSdk to 26, and wires the data module into the app.
* Removes the empty data AndroidManifest and updates presentation to match new dependencies.